### PR TITLE
Add software for specifying directory of secret storage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,18 @@ var storage = require('dat-storage')
 
 // files are stored in ./my-dataset
 // metadata (hashes and stuff) are stored in ./my-dataset/.dat
+// secret keys are stored in ~/.dat/secret_keys/<discovery-key>
 var archive = hyperdrive(storage('my-dataset'))
+```
+
+### Secret Keys
+
+By default secret keys are stored in the users home directory via [dat-secret-storage](https://github.com/joehand/dat-secret-storage). To change the directory, pass it as an option:
+
+```js
+var storaage = require('dat-storage')
+
+var archive = hyperdrive(storage('my-dataset', {secretDir: '/secret_keys'})
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -6,10 +6,16 @@ var stat = require('hyperdrive/lib/messages').Stat
 var path = require('path')
 
 module.exports = function (dir) {
+  let secret_dir = undefined;
+  if (typeof dir === 'object') {
+    secret_dir = dir.secret_dir;
+    dir = dir.dir;
+  }
+
   return {
     metadata: function (name, opts) {
       if (typeof dir === 'function') return dir('.dat/metadata.' + name)
-      if (name === 'secret_key') return secretStorage()(path.join(dir, '.dat/metadata.ogd'), {key: opts.key, discoveryKey: opts.discoveryKey})
+      if (name === 'secret_key') return secretStorage(secret_dir)(path.join(dir, '.dat/metadata.ogd'), {key: opts.key, discoveryKey: opts.discoveryKey})
       return raf(path.join(dir, '.dat/metadata.' + name))
     },
     content: function (name, opts, archive) {

--- a/index.js
+++ b/index.js
@@ -5,17 +5,13 @@ var messages = require('append-tree/messages')
 var stat = require('hyperdrive/lib/messages').Stat
 var path = require('path')
 
-module.exports = function (dir) {
-  let secret_dir = undefined;
-  if (typeof dir === 'object') {
-    secret_dir = dir.secret_dir;
-    dir = dir.dir;
-  }
+module.exports = function (dir, opts) {
+  if (!opts) opts = {}
 
   return {
     metadata: function (name, opts) {
       if (typeof dir === 'function') return dir('.dat/metadata.' + name)
-      if (name === 'secret_key') return secretStorage(secret_dir)(path.join(dir, '.dat/metadata.ogd'), {key: opts.key, discoveryKey: opts.discoveryKey})
+      if (name === 'secret_key') return secretStorage(opts.secretDir)(path.join(dir, '.dat/metadata.ogd'), {key: opts.key, discoveryKey: opts.discoveryKey})
       return raf(path.join(dir, '.dat/metadata.' + name))
     },
     content: function (name, opts, archive) {


### PR DESCRIPTION
Secret storage specification occurs when the directory passed to
createStore is specified as an object rather than a string. That object
takes the form of:
{dir: 'data-dir', secret_dir: 'secrets'}